### PR TITLE
measure FCD frame rates and restart FCD if stalled

### DIFF
--- a/master/public/javascripts/sensorgnome.js
+++ b/master/public/javascripts/sensorgnome.js
@@ -339,7 +339,7 @@ function onVahstatus (status) {
         timeTxt += (' <span id="pps" style="color: ' + (ppsOK ? "green" : "red") + '">PPS ' + (ppsOK ? "present" : "missing") + '</span>');
     }
     $('#sgtime').html(timeTxt);
-    var tabHdr="<table><tr><th>USB Port #</th><th>Hardware<br>Frame Rate (kHz)<br>Obs. / Set</th><th>Plugin<br>Frame Rate (kHz)<br>Obs. / Set</th><th>Channels</th><th>Plugin</th><th>Current<br>Feature Detection Rate<br>pulses per minute</th><th>Long-term<br>Feature Detection Rate<br>pulses per minute</th><th>(Re)Started</th></tr>";
+    var tabHdr="<table><tr><th>USB Port #</th><th>Hardware<br>Frame Rate (kHz)<br>Obs. / Set</th><th>Plugin<br>Frame Rate (kHz)<br>Obs. / Set</th><th>Channels</th><th>Plugin</th><th>Current<br>Feature Detection Rate<br>pulses per minute</th><th>Long-term<br>Feature Detection Rate<br>pulses per minute</th><th>Stalls</th><th>(Re)Started</th></tr>";
     var txt = "";
     for (n in status) {
         var item = status[n];
@@ -359,7 +359,7 @@ function onVahstatus (status) {
         for (p in fcd.plugins) {
             var plugin = fcd.plugins[p];
             var pulse_rate, hw_rate, tot_pulse_rate, sw_rate;
-            var oldfcd;
+            var oldfcd, stalls='?';
             if (VAHstatus)
                 oldfcd = VAHstatus[n];
             if (oldfcd) {
@@ -373,7 +373,13 @@ function onVahstatus (status) {
                 pulse_rate = plugin.totalFeatures / fcd.totalFrames * fcd.hwRate;
             }
             tot_pulse_rate = plugin.totalFeatures / fcd.totalFrames * fcd.hwRate;
-            txt += "<tr><td>" + n + "</td><td>" + (hw_rate / 1000).toFixed(1) + " / " + (fcd.hwRate/1000).toFixed(1) + "</td><td>" + (sw_rate / 1000).toFixed(1) + " / " + (plugin.rate / 1000).toFixed(1) + "</td><td>" + fcd.numChan + "</td><td>" + p + "</td><td>"+ (pulse_rate * 60).toFixed(4) + "</td><td>" + (tot_pulse_rate * 60).toPrecision(6) + "</td><td>" + (new Date(fcd.startTimestamp * 1000)).toUTCString() + "</td></tr>";
+            if (n in status.stalls) stalls = status.stalls[n];
+            txt += "<tr><td>" + n + "</td><td>" + (hw_rate / 1000).toFixed(1) + " / " + (fcd.hwRate/1000).toFixed(1) + "</td><td>" +
+                (sw_rate / 1000).toFixed(1) + " / " + (plugin.rate / 1000).toFixed(1) + "</td><td>" +
+                fcd.numChan + "</td><td>" + p + "</td><td>"+ (pulse_rate * 60).toFixed(4) + "</td><td>" +
+                (tot_pulse_rate * 60).toPrecision(6) + "</td><td>" +
+                stalls + "</td><td>" +
+                (new Date(fcd.startTimestamp * 1000)).toUTCString() + "</td></tr>";
         }
     }
     if (txt != "")

--- a/master/usbaudio.js
+++ b/master/usbaudio.js
@@ -101,7 +101,7 @@ USBAudio.prototype.hw_startStop = function(on) {
 USBAudio.prototype.hw_stalled = function() {
     // reset this device
     if (this.command) {
-	console.log("got to hw_stalled\n");
+        console.log(`USBAudio: ${this.dev.attr.usbPath}: resetting`);
         ChildProcess.execFile(this.command, this.baseArgs.concat("-R"));
     }
     var dev = JSON.parse(JSON.stringify(this.dev));

--- a/master/webserver.js
+++ b/master/webserver.js
@@ -147,7 +147,7 @@ WebServer.prototype.pushDeviceInfo = function (err, stdout, stderr) {
                 try {
                     info[d].settings = devs[d].settings;
                 } catch(err) {
-                    console.log('error sith this settings');
+                    console.log('error with devs settings');
                     info[d].settings = null;
                 }
             }
@@ -227,6 +227,7 @@ WebServer.prototype.pushVAHStatus = function (data) {
             if (ppsCount)
                 data.ppsCount = ppsCount[1] ? ppsCount[1] : 0;
             data.clockSyncDigits = GPS.clockSyncDigits;
+        data.stalls = Sensor.getStalls();
 	    this.sock.emit('vahstatus', data);
 	} catch (e) {
 	    console.log("Unable to display status of vamp-alsa-server process!");


### PR DESCRIPTION
This PR adds code to vah.js to periodically check the FCD sample rate and restart the FCD if it fall outside of bounds. It also adds a "stalls" column to show the number of such events to the UI table that lists FCDs and their sample rates.
This code likely needs more testing (I don't have enough FCDs to be able to reproduce the issue myself).