### PR TITLE
Fix issues with sample rate checker

### DIFF
--- a/master/sensor.js
+++ b/master/sensor.js
@@ -97,7 +97,7 @@ Sensor.prototype.devRemoved = function(dev) {
 
 Sensor.prototype.devStalled = function(vahDevLabel) {
     console.log("Got devStalled with " + vahDevLabel + "\n");
-    if (vahDevLabel = this.dev.attr.port)
+    if (vahDevLabel == this.dev.attr.port)
         this.stalled();
 };
 

--- a/master/sensor.js
+++ b/master/sensor.js
@@ -96,9 +96,10 @@ Sensor.prototype.devRemoved = function(dev) {
 };
 
 Sensor.prototype.devStalled = function(vahDevLabel) {
-    console.log("Got devStalled with " + vahDevLabel + "\n");
-    if (vahDevLabel == this.dev.attr.port)
+    if (vahDevLabel == 'p'+this.dev.attr.port) {
+        console.log("Got devStalled with " + vahDevLabel + "\n");
         this.stalled();
+    }
 };
 
 Sensor.prototype.init = function() {

--- a/master/usbaudio.js
+++ b/master/usbaudio.js
@@ -103,6 +103,7 @@ USBAudio.prototype.hw_stalled = function() {
     if (this.command) {
         console.log(`USBAudio: ${this.dev.attr.usbPath}: resetting`);
         ChildProcess.execFile(this.command, this.baseArgs.concat("-R"));
+        // FIXME: probably need a timeout to force-kill if the fcd reset process hangs
     }
     var dev = JSON.parse(JSON.stringify(this.dev));
     // re-add after 5 seconds

--- a/master/vah.js
+++ b/master/vah.js
@@ -59,7 +59,10 @@ VAH = function(matron, prog, sockName) {
     this.reapOldVAHandSpawn();
 }
 
-const checkRatesInterval = 20_000;
+// sample rate checker parameters
+const checkRatesInterval = 10_000; // ms
+const maxOutOfBounds = 2; // number of consecutive OOB checks that trigger a reset
+const boundsPCT = 5; // nominal +/- bounds percentage
 
 VAH.prototype.childDied = function(code, signal) {
 //    console.log("VAH child died\n")
@@ -119,10 +122,6 @@ VAH.prototype.cmdSockConnected = function() {
 //        console.log("VAH about to submit queued: " + this.commandQueue[0] + "\n");
         this.cmdSock.write(this.commandQueue.shift());
     }
-    // start monitoring sample rates
-    // need to wait a long time for VAH to respond to the first list command (prob has to 
-    // start all plugin processes and get some OK from them)
-    this.checkRateTimer = setInterval(() => this.checkRates(), checkRatesInterval);
 };
 
 VAH.prototype.serverReady = function(data) {
@@ -214,8 +213,9 @@ VAH.prototype.vahStartStop = function (startstop, devLabel, callback, callbackPa
     const cmd = startstop + " " + devLabel;
     this.vahSubmit(cmd, callback, callbackPars);
     // info from VAH comes back as 'pN', the 'p' stands for Plugin...
-    if (startstop == 'start') this.frames['p'+devLabel] = { at: Date.now(), frames: 0, bad: 0 };
-    else delete this.frames['p'+devLabel];
+    if (startstop != 'start') {
+        delete this.frames['p'+devLabel]; // remove plugin from list being monitored
+    }
 };
 
 
@@ -259,6 +259,13 @@ VAH.prototype.vahAccept = function(pluginLabel) {
     if (this.dataSock) {
 //        console.log("VAH about to do receive " + pluginLabel + "\n");
         this.dataSock.write("receive " + pluginLabel + "\n");
+        this.frames[pluginLabel] = { at: Date.now(), frames: null, bad: 0 };
+        if (!this.checkRateTimer) {
+            // start monitoring sample rates
+            // doing this here so we get a prompt response to the first list command
+            this.checkRateTimer = setInterval(() => this.checkRates(), checkRatesInterval);
+            this.checkRates(); // this may be too early, TBD...
+        }
     }
 };
 
@@ -273,7 +280,6 @@ VAH.prototype.quit = function() {
 
 VAH.prototype.getRawStream = function(devLabel, rate, doFM) {
     // return a readableStream which will produce raw output from the specified device, until the socket is closed
-
     var rawSock = Net.connect(this.sockPath, function(){});
     rawSock.stop = function() {rawSock.write("rawStreamOff " + devLabel + "\n"); rawSock.destroy();}
 
@@ -288,10 +294,15 @@ VAH.prototype.checkRates = function() {
 var logRateCnt = 0;
 
 VAH.prototype.checkRatesReply = function(reply) {
+    // NOTE: `p` in this function refers to a value like `p2` where the `p` really stands for
+    // VAH Plugin, but `p` is also used as Port designator here. The use of the same letter is
+    // actually a coincidence. It works, but not great.
     // check that all the plugins are producing data at the correct rate
     const now = Date.now()
+    const minFct = 1 - boundsPCT/100
+    const maxFct = 1 + boundsPCT/100
     // console.log("VAH rates: ", JSON.stringify(reply, null, 2));
-    // console.log(`VAH frames: ${JSON.stringify(this.frames, null, 2)}`);
+    console.log(`VAH frames: ${JSON.stringify(this.frames, null, 2)}`);
     for (const p in this.frames) {
         const fp = this.frames[p];
         if (p in reply) {
@@ -300,7 +311,15 @@ VAH.prototype.checkRatesReply = function(reply) {
                 console.log(`VAH checkRates: ${p} is not a plugin? ${JSON.stringify(info)}`);
                 continue;
             }
+            console.log(`VAH info for ${p} at ${now} (dt=${now-fp.at}): ${JSON.stringify(info, null, 2)}`);
             this.matron.emit("vahFrames", p, now, info.totalFrames);
+            // if fp.frames is null it just started and we don't have an initial frame count, so
+            // get that (we used to set frames to 0 when starting but it takes a long time to actually
+            // start and that caused low frame rates)
+            if (fp.frames === null) {
+                this.frames[p] = { ...fp, at: now, frames: info.totalFrames };
+                continue;
+            }
             // calculate the rate
             const dt = now - fp.at;
             if (dt < checkRatesInterval*0.9) continue; // too soon to calculate stable rate
@@ -308,15 +327,19 @@ VAH.prototype.checkRatesReply = function(reply) {
             const rate = df / dt * 1000;
             this.matron.emit("vahRate", p, now, rate);
             // OK or not?
-            const ok = rate > info.rate*0.95 && rate < info.rate*1.05;
+            const ok = rate > info.rate*minFct && rate < info.rate*maxFct;
             if (!ok || logRateCnt++ < 100)
                 console.log(`VAH rate for ${p}: nominal ${info.rate}, actual ${rate.toFixed(0)} frames/sec`);
             if (!ok) fp.bad++; else fp.bad = 0;
-            if (fp.bad > 6) {
-                console.log(`VAH rate for ${p} is out of range: nominal ${info.rate}, actual ${rate.toFixed(0)} frames/sec`);
+            if (fp.bad >= maxOutOfBounds) {
+                const msg = `VAH rate for ${p} is out of range: nominal ${info.rate}, actual ${rate.toFixed(0)} frames/sec`
+                console.log(msg);
                 this.matron.emit("devStalled", p);
+                fp.bad = 0; // reset count so we don't continuously signal devStalled
             }
-        } else if (fp.frames > 0 || Date.now() - fp.at > 60_000) {
+            // Update the current frame count for the next check
+            this.frames[p] = { ...fp, at: now, frames: info.totalFrames };
+        } else if (fp.frames > 0 || Date.now() - fp.at > checkRatesInterval*0.9) {
             // plugin has died
             console.log(`VAH plugin ${p} has died`);
             this.matron.emit("devStalled", p);


### PR DESCRIPTION
This PR fixes a number of issues with the sample rate checker:
- constants are factored out at the beginning of vah.js
- rates are calculated for each check interval
- the devStalled propagation is fixed

The value of the check interval and max out of bounds count are for testing purposes, I believe appropriate are perhaps an interval of 3 minutes and 3 consecutive OOB with the result that a restart is triggered after 9 minutes.